### PR TITLE
update nvidia_nim.rs e2e initialization for embeddings

### DIFF
--- a/tensorzero-core/tests/e2e/providers/nvidia_nim.rs
+++ b/tensorzero-core/tests/e2e/providers/nvidia_nim.rs
@@ -92,5 +92,6 @@ async fn get_providers() -> E2ETestProviders {
         image_inference: vec![],
         pdf_inference: vec![],
         shorthand_inference: shorthand_providers.clone(),
+        embeddings: vec![],
     }
 }


### PR DESCRIPTION
Resolving initialization

error here
https://github.com/SnazofSnaz/tensorzero/actions/runs/16822428033/job/47651900703

Nvidia focus with this is inference models not embeddings - need empty vector initialized for this to prevent error.

The error was specifically complaining about a missing field embeddings in the struct initializer: